### PR TITLE
Do not deploy in Cypress docker image

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,9 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request runs the deployment workflow in the `ubuntu-20.04` runner and removes the Cypress docker image to be able to run `docker` commands from the same runner.