### PR TITLE
Avoid running the test workflow on deploys

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags-ignore:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
   pull_request:
 
 jobs:      


### PR DESCRIPTION
When a tag is pushed a `deploy`workflow runs, before deploying the end-to-end tests run, there is no need to run the `test` workflow in these cases because the tag will be tested anyway and if the tests fail it will not deploy the tag.