### PR TITLE
Use cypress-wait-until to check from Home Assistant elements before starting each test

### DIFF
--- a/cypress/e2e/lovelace.e2e.spec.cy.ts
+++ b/cypress/e2e/lovelace.e2e.spec.cy.ts
@@ -10,6 +10,8 @@ describe('HAQuerySelector for lovelace dashboards', () => {
             .window()
             .its('HAQuerySelector');
 
+        cy.waitForHomeAssistantDOM();
+
         cy
             .window()
             .then((win) => {

--- a/cypress/e2e/more-info-dialogs.e2e.spec.cy.ts
+++ b/cypress/e2e/more-info-dialogs.e2e.spec.cy.ts
@@ -10,6 +10,8 @@ describe('HAQuerySelector for more-info dialogs', () => {
             .window()
             .its('HAQuerySelector');
 
+        cy.waitForHomeAssistantDOM();
+
         cy
             .get('home-assistant')
             .shadow()

--- a/cypress/global.ts
+++ b/cypress/global.ts
@@ -4,6 +4,7 @@ declare global {
   namespace Cypress {
     interface Chainable {
       ingress(): Chainable<void>;
+      waitForHomeAssistantDOM(): Chainable<void>;
     }
   }
   interface Window {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -36,6 +36,8 @@
 //   }
 // }
 
+import 'cypress-wait-until';
+
 Cypress.Commands.add('ingress', () => {
 
     cy.session('home-assistant', () => {
@@ -47,5 +49,21 @@ Cypress.Commands.add('ingress', () => {
 
     });
           
+
+});
+
+Cypress.Commands.add('waitForHomeAssistantDOM', () => {
+
+    cy.waitUntil(() => (
+        cy
+            .get('home-assistant')
+            .shadow()
+            .find('home-assistant-main')
+            .shadow()
+            .find('ha-drawer partial-panel-resolver ha-panel-lovelace')
+            .shadow()
+            .find('hui-root')
+            .shadow()
+    ));
 
 });

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@typescript-eslint/eslint-plugin": "^6.11.0",
     "@typescript-eslint/parser": "^6.11.0",
     "cypress": "^13.5.1",
+    "cypress-wait-until": "^2.0.1",
     "eslint": "^8.53.0",
     "rollup": "^4.4.1",
     "rollup-plugin-istanbul": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1077,6 +1077,11 @@ crosspath@^2.0.0:
   dependencies:
     "@types/node" "^17.0.36"
 
+cypress-wait-until@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/cypress-wait-until/-/cypress-wait-until-2.0.1.tgz#69c575c7207d83e4ae023e2aaecf2b66148c9fc0"
+  integrity sha512-+IyVnYNiaX1+C+V/LazrJWAi/CqiwfNoRSrFviECQEyolW1gDRy765PZosL2alSSGK8V10Y7BGfOQyZUDgmnjQ==
+
 cypress@^13.5.1:
   version "13.5.1"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.5.1.tgz#8b19bf0b9f31ea43f78980b2479bd3f25197d5cc"


### PR DESCRIPTION
Sometimes the tests fail because Cypress cannot find the elements in the DOM. Home Assistant elements take time to be ready (that is the whole purpose of this library), so, this pull request makes use of the [cypress-wait-until](https://www.npmjs.com/package/cypress-wait-until) package to wait for the lovelace element to be ready before running each test.

<img width="872" alt="image" src="https://github.com/elchininet/home-assistant-query-selector/assets/3728220/2a5ae2e3-affe-4bd5-a8c0-db2d12225d54">
