### PR TITLE
Do not bundle `shadow-dom-selector`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.3] - 2023-11-20
+
+- Do not bundle `shadow-dom-selector` inside the final bundle of `home-assistant-query-selector`
+
 ## [1.1.2] - 2023-11-20
 
 - Fix typos in events prefixes

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,6 @@ import istanbul from 'rollup-plugin-istanbul';
 export default [
     {
         plugins: [
-            nodeResolve(),
             ts({
                 browserslist: false
             }),
@@ -20,18 +19,14 @@ export default [
         output: [
             {
                 file: 'dist/index.js',
-                format: 'cjs',
+                format: 'cjs'
             },
             {
                 file: 'dist/esm/index.js',
                 format: 'esm'
-            },
-            {
-                file: 'dist/test/index.js',
-                format: 'iife',
-                name: 'HomeAssistantQuerySelector'
             }
-        ]
+        ],
+        external: ['shadow-dom-selector']
     },
     {
         plugins: [


### PR DESCRIPTION
This pull request avoids bundling the `shadow-dom-selector` inside of the final bundle. The only module that needs to have the `shadow-dom-selector` package is the bundle for the end-to-end tests.