### PR TITLE
Add a waitForFunction at the end of the stubGlobalTestElements utility

### DIFF
--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -73,8 +73,8 @@ export const stubGlobalTestElements = async (
             HAQuerySelectorEvent.ON_SETTINGS_DIALOG_OPEN,
             window.__onSettingsDialogOpen
         );
-
         window.__instance.listen();
 
     }, options || {});
+    await page.waitForFunction(() => !!window.__onListen?.firstCall?.firstArg);
 };


### PR DESCRIPTION
Multiple times the tests fails randomly with:

```bash
Error: page.evaluate: TypeError: Cannot read properties of null (reading 'firstArg')
```

So, this means that sometimes some `sinon` fake functions have not been triggered in the moment that a test runs. To avoid this a `waitForFunction` has been added at the end of the `stubGlobalTestElements` test utility to make sure the stub is ready before starting the tests.