### PR TITLE
UImprove tests. Use page.initScript instead context.initScript

### DIFF
--- a/.github/workflows/ha-beta-tests.yaml
+++ b/.github/workflows/ha-beta-tests.yaml
@@ -25,3 +25,10 @@ jobs:
         run: pnpm install
       - name: E2E Tests
         run: TAG=beta pnpm test:ci
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-report
+          path: |
+            playwright-report
+          retention-days: 30

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,3 +42,11 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-report
+          path: |
+            playwright-report/
+            coverage/
+          retention-days: 30

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,8 +31,12 @@ export default defineConfig({
     // baseURL: 'http://127.0.0.1:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry'
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure'
   },
+  expect: {
+		timeout: 15000
+	},
   /* Configure projects for major browsers */
   projects: [
     {

--- a/tests/01 - panels.spec.ts
+++ b/tests/01 - panels.spec.ts
@@ -4,8 +4,8 @@ import { stubGlobalTestElements } from './utils';
 
 test.describe('HAQuerySelector for dashboards', () => {
 
-    test.beforeEach(async ({ page, context }) => {
-        await stubGlobalTestElements(page, context);
+    test.beforeEach(async ({ page }) => {
+        await stubGlobalTestElements(page);
 	});
 
     test('All the elements should exist', async ({ page }) => {

--- a/tests/02 - low-event-timestamp.spec.ts
+++ b/tests/02 - low-event-timestamp.spec.ts
@@ -4,10 +4,9 @@ import { stubGlobalTestElements } from './utils';
 
 test.describe('HAQuerySelector events with low timestamp', () => {
 
-    test.beforeEach(async ({ page, context }) => {
+    test.beforeEach(async ({ page }) => {
         await stubGlobalTestElements(
             page,
-            context,
             {
                 eventThreshold: 800
             }

--- a/tests/03 - more-info-dialogs.spec.ts
+++ b/tests/03 - more-info-dialogs.spec.ts
@@ -4,8 +4,8 @@ import { stubGlobalTestElements } from './utils';
 
 test.describe('HAQuerySelector for more-info dialogs', () => {
 
-    test.beforeEach(async ({ page, context }) => {
-        await stubGlobalTestElements(page, context);
+    test.beforeEach(async ({ page }) => {
+        await stubGlobalTestElements(page);
 	});
 
     test.afterEach(async ({ page }) => {

--- a/tests/04 - non-existent-elements.spec.ts
+++ b/tests/04 - non-existent-elements.spec.ts
@@ -3,10 +3,9 @@ import { stubGlobalTestElements } from './utils';
 
 test.describe('HAQuerySelector for lovelace dashboards', () => {
 
-    test.beforeEach(async ({ page, context }) => {
+    test.beforeEach(async ({ page }) => {
         await stubGlobalTestElements(
             page,
-            context,
             {
                 retries: 5,
                 delay: 5

--- a/tests/05 - non-lovelace.spec.ts
+++ b/tests/05 - non-lovelace.spec.ts
@@ -3,10 +3,9 @@ import { stubGlobalTestElements } from './utils';
 
 test.describe('HAQuerySelector for non-lovelace dashboards', () => {
 
-    test.beforeEach(async ({ page, context }) => {
+    test.beforeEach(async ({ page }) => {
         await stubGlobalTestElements(
             page,
-            context,
             {
                 pathname: 'history',
                 retries: 5,

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,4 +1,4 @@
-import { Page, BrowserContext } from '@playwright/test';
+import { Page } from '@playwright/test';
 import { expect } from 'playwright-test-coverage';
 import path from 'path';
 import { BASE_URL, SELECTORS } from './constants';
@@ -12,11 +12,10 @@ interface Options {
 
 export const stubGlobalTestElements = async (
     page: Page,
-    context: BrowserContext,
     options?: Options
 ) => {
 
-    await context.addInitScript({
+    await page.addInitScript({
         path: path.join(__dirname, '..', './node_modules/sinon/pkg/sinon.js'),
     });
 
@@ -76,5 +75,6 @@ export const stubGlobalTestElements = async (
         window.__instance.listen();
 
     }, options || {});
-    await page.waitForFunction(() => !!window.__onListen?.firstCall?.firstArg);
+    // Timeout to allow the events to be triggered
+    await page.waitForTimeout(500);
 };


### PR DESCRIPTION
This pull request tries to improve the tests refactoring their utilities. The `context.initScript` has been changed to `page.initScript`because there is not a specific reason to use the first one.