### PR TITLE
Restore setup node resgistry-url

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -19,6 +19,7 @@ jobs:
         with:
           version: 8
           run_install: false
+          registry-url: 'https://registry.npmjs.org'
       - name: Set-up Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
During the migration to pnpm the registry-url parameter of the Node set up step was removed. This pull request restores it.