### PR TITLE
Specify timezone and time in Dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
       day: "sunday"
+      time: "09:00"
+      timezone: "Europe/Amsterdam"
     commit-message:
       prefix: "[Dependencies]"
     ignore:


### PR DESCRIPTION
This pull request specifies [schedule.time](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduletime) and [schedule.timezone](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduletimezone) in Dependabot config.