### PR TITLE
Get the Playwright version from the package.json to create the Docker cache id

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,10 +25,14 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
+      - name: Set Playwright version
+        id: playwright-version
+        run: |
+          echo "playwright=$(cat package.json | grep @playwright/test | head -1 | awk -F: '{ print $2 }' | sed 's/[", ]//g')" >> $GITHUB_OUTPUT
       - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.3.6
         with:
-          key: docker-v1-${{ runner.os }}-${{ hashFiles('.hass/config/.HA_VERSION', '.playwright_docker_version') }}
+          key: docker-v1-${{ runner.os }}-${{ hashFiles('.hass/config/.HA_VERSION') }}-${{ steps.playwright-version.outputs.playwright }}
       - name: Publish
         run: |
           pnpm install

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,10 +24,14 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
+      - name: Set Playwright version
+        id: playwright-version
+        run: |
+          echo "playwright=$(cat package.json | grep @playwright/test | head -1 | awk -F: '{ print $2 }' | sed 's/[", ]//g')" >> $GITHUB_OUTPUT
       - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.3.6
         with:
-          key: docker-v1-${{ runner.os }}-${{ hashFiles('.hass/config/.HA_VERSION', '.playwright_docker_version') }}
+          key: docker-v1-${{ runner.os }}-${{ hashFiles('.hass/config/.HA_VERSION') }}-${{ steps.playwright-version.outputs.playwright }}
       - name: Install
         run: pnpm install
       - name: Linting Code


### PR DESCRIPTION
This pull request gets the `Playwright` version from the `package.json` to create the `Docker Cache` id during the Github workflows.