### PR TITLE
Remove ScribeMD/docker-cache Github action from the Workflows

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,14 +25,6 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
-      - name: Set Playwright version
-        id: playwright-version
-        run: |
-          echo "playwright=$(cat package.json | grep @playwright/test | head -1 | awk -F: '{ print $2 }' | sed 's/[", ]//g')" >> $GITHUB_OUTPUT
-      - name: Cache Docker images
-        uses: ScribeMD/docker-cache@0.3.6
-        with:
-          key: docker-v1-${{ runner.os }}-${{ hashFiles('.hass/config/.HA_VERSION') }}-${{ steps.playwright-version.outputs.playwright }}
       - name: Publish
         run: |
           pnpm install

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,14 +24,6 @@ jobs:
         with:
           node-version: '18'
           cache: 'pnpm'
-      - name: Set Playwright version
-        id: playwright-version
-        run: |
-          echo "playwright=$(cat package.json | grep @playwright/test | head -1 | awk -F: '{ print $2 }' | sed 's/[", ]//g')" >> $GITHUB_OUTPUT
-      - name: Cache Docker images
-        uses: ScribeMD/docker-cache@0.3.6
-        with:
-          key: docker-v1-${{ runner.os }}-${{ hashFiles('.hass/config/.HA_VERSION') }}-${{ steps.playwright-version.outputs.playwright }}
       - name: Install
         run: pnpm install
       - name: Linting Code


### PR DESCRIPTION
This pull request removes the `ScribeMD/docker-cache` Github action from the Workflows because it takes more time to decompress the cache than to download the image from Docker Hub.