### PR TITLE
Do not rely on package.json variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "stop:ha": "docker stop $(docker ps -a -q  --filter ancestor=homeassistant/home-assistant:${TAG:-$(cat .hass/config/.HA_VERSION)}) || true",
     "reset:ha": "git add .hass/config/.HA_VERSION && git checkout .hass/config",
     "demo:ha": "pnpm test:clean && pnpm build && pnpm start:ha",
-    "start:playwright": "docker run --rm --network host --add-host host.docker.internal:host-gateway -v $(pwd):/$(pwd)/ -w $(pwd) -i mcr.microsoft.com/playwright:v$npm_package_devDependencies__playwright_test-jammy sh -c \"npx playwright test\"",
+    "start:playwright": "docker run --rm --network host --add-host host.docker.internal:host-gateway -v $(pwd):/$(pwd)/ -w $(pwd) -i mcr.microsoft.com/playwright:v$(jq -r '.devDependencies[\"@playwright/test\"]' package.json)-jammy sh -c \"npx playwright test\"",
     "prepare": "pnpm build",
     "prepublishOnly": "pnpm lint && pnpm test:ts && pnpm test:ci",
     "version": "git add .",


### PR DESCRIPTION
Since `pnpm@10` it is not possible to access package.json variables because a [breaking change](https://github.com/pnpm/pnpm/issues/9034#issuecomment-2633428229). For now we have kept using `pnpm@9` to avoid breaking the tests scripts which take the `@playwright/test` version from `devDependencies` to know which [Playwright Docker image tag](https://playwright.dev/docs/docker) it needs to use, using builtin `package.json` variables.

In this pull request the `@playwright/test` version is taken using a [jq](https://github.com/jqlang/jq) command. This allows us to migrate to `pnpm@10`.