### PR TITLE
Update PNPM in Github workflows

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
           run_install: false
       - name: Set-up Node
         uses: actions/setup-node@v4

--- a/.github/workflows/ha-beta-tests.yaml
+++ b/.github/workflows/ha-beta-tests.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
           run_install: false
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
           run_install: false
       - name: Set up Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
After removing the dependency on `package.json` builtin variables, the project is ready to migrate to `pnpm@10`. This pull request bumps `pnpm` to version `10` in the Github workflows.