### PR TITLE
Remove tests compatibility with old versions of Home Assistant

### DIFF
--- a/tests/01 - panels.spec.ts
+++ b/tests/01 - panels.spec.ts
@@ -201,16 +201,13 @@ test.describe('HAQuerySelector for dashboards', () => {
 
     test('Events should be triggered accordingly', async ({ page }) => {
 
-        // In Home Assistant 2025.05.x is ha-md-list > ha-md-list-item
-        const links = ':is(paper-listbox, ha-md-list) > :is(a[role="option"], ha-md-list-item)';
-
         expect(await page.evaluate(() => window.__onListen.calledOnce)).toBe(true);
         expect(await page.evaluate(() => window.__onPanelLoad.calledOnce)).toBe(true);
         expect(await page.evaluate(() => window.__onLovelacePanelLoad.calledOnce)).toBe(true);
 
         await page.waitForTimeout(600);
 
-        await page.locator(links, { hasText: 'History' }).click();
+        await page.locator(SELECTORS.LINKS, { hasText: 'History' }).click();
         await expect(page.locator(SELECTORS.HEADER_HISTORY)).toBeVisible();
 
         expect(await page.evaluate(() => window.__onListen.calledOnce)).toBe(true);
@@ -219,7 +216,7 @@ test.describe('HAQuerySelector for dashboards', () => {
 
         await page.waitForTimeout(600);
 
-        await page.locator(links, { hasText: 'Overview' }).click();
+        await page.locator(SELECTORS.LINKS, { hasText: 'Overview' }).click();
         await expect(page.locator(SELECTORS.ENTITY_CARD)).toBeVisible();
 
         expect(await page.evaluate(() => window.__onListen.calledOnce)).toBe(true);
@@ -238,9 +235,6 @@ test.describe('HAQuerySelector for dashboards', () => {
 
     test('Remove events should remove the listeners', async ({ page }) => {
 
-        // In Home Assistant 2025.05.x is ha-md-list > ha-md-list-item
-        const links = ':is(paper-listbox, ha-md-list) > :is(a[role="option"], ha-md-list-item)';
-
         expect(await page.evaluate(() => window.__onListen.calledOnce)).toBe(true);
         expect(await page.evaluate(() => window.__onPanelLoad.calledOnce)).toBe(true);
         expect(await page.evaluate(() => window.__onLovelacePanelLoad.calledOnce)).toBe(true);
@@ -252,7 +246,7 @@ test.describe('HAQuerySelector for dashboards', () => {
             window.__instance.removeEventListener(HAQuerySelectorEvent.ON_LOVELACE_PANEL_LOAD, window.__onLovelacePanelLoad);
         });
 
-        await page.locator(links, { hasText: 'History' }).click();
+        await page.locator(SELECTORS.LINKS, { hasText: 'History' }).click();
         await expect(page.locator(SELECTORS.HEADER_HISTORY)).toBeVisible();
 
         expect(await page.evaluate(() => window.__onListen.calledOnce)).toBe(true);
@@ -261,7 +255,7 @@ test.describe('HAQuerySelector for dashboards', () => {
 
         await page.waitForTimeout(600);
 
-        await page.locator(links, { hasText: 'Overview' }).click();
+        await page.locator(SELECTORS.LINKS, { hasText: 'Overview' }).click();
         await expect(page.locator(SELECTORS.ENTITY_CARD)).toBeVisible();
 
         expect(await page.evaluate(() => window.__onListen.calledOnce)).toBe(true);

--- a/tests/02 - low-event-timestamp.spec.ts
+++ b/tests/02 - low-event-timestamp.spec.ts
@@ -15,19 +15,16 @@ test.describe('HAQuerySelector events with low timestamp', () => {
 
     test('Do not fire events below eventThreshold', async ({ page }) => {
 
-        // In Home Assistant 2025.05.x is ha-md-list > ha-md-list-item
-        const links = ':is(paper-listbox, ha-md-list) > :is(a[role="option"], ha-md-list-item)';
-
         expect(await page.evaluate(() => window.__onPanelLoad.calledOnce)).toBe(true);
         expect(await page.evaluate(() => window.__onLovelacePanelLoad.calledOnce)).toBe(true);
 
-        await page.locator(links, { hasText: 'History' }).click();
+        await page.locator(SELECTORS.LINKS, { hasText: 'History' }).click();
         await expect(page.locator(SELECTORS.HEADER_HISTORY)).toBeVisible();
 
         expect(await page.evaluate(() => window.__onPanelLoad.calledTwice)).toBe(false);
         expect(await page.evaluate(() => window.__onLovelacePanelLoad.calledTwice)).toBe(false);
 
-        await page.locator(links, { hasText: 'Overview' }).click();
+        await page.locator(SELECTORS.LINKS, { hasText: 'Overview' }).click();
         await expect(page.locator(SELECTORS.ENTITY_CARD)).toBeVisible();
 
         expect(await page.evaluate(() => window.__onPanelLoad.calledThrice)).toBe(false);
@@ -35,7 +32,7 @@ test.describe('HAQuerySelector events with low timestamp', () => {
 
         await page.waitForTimeout(1500);
 
-        await page.locator(links, { hasText: 'History' }).click();
+        await page.locator(SELECTORS.LINKS, { hasText: 'History' }).click();
         await expect(page.locator(SELECTORS.HEADER_HISTORY)).toBeVisible();
 
         expect(await page.evaluate(() => window.__onPanelLoad.calledTwice)).toBe(true);
@@ -43,7 +40,7 @@ test.describe('HAQuerySelector events with low timestamp', () => {
 
         await page.waitForTimeout(1500);
 
-        await page.locator(links, { hasText: 'Overview' }).click();
+        await page.locator(SELECTORS.LINKS, { hasText: 'Overview' }).click();
         await expect(page.locator(SELECTORS.ENTITY_CARD)).toBeVisible();
 
         expect(await page.evaluate(() => window.__onPanelLoad.calledThrice)).toBe(true);

--- a/tests/03 - more-info-dialogs.spec.ts
+++ b/tests/03 - more-info-dialogs.spec.ts
@@ -15,17 +15,9 @@ test.describe('HAQuerySelector for more-info dialogs', () => {
             return window.getComputedStyle(body).getPropertyValue('overflow') === 'hidden';
         });
         if (isOverflow) {
-            // Restore this after Home Assistant 2025.3.x is released
-            //await page.locator(SELECTORS.CLOSE_DIALOG).click();
-            await page.locator(SELECTORS.CLOSE_DIALOG)
-                .or(page.locator(SELECTORS.CLOSE_DIALOG_OLD))
-                .click();
+            await page.locator(SELECTORS.CLOSE_DIALOG).click();
         }
-        // Restore this after Home Assistant 2025.3.x is released
-        //await expect(page.locator(SELECTORS.CLOSE_DIALOG)).not.toBeVisible();
-        await expect(
-            page.locator(SELECTORS.CLOSE_DIALOG).or(page.locator(SELECTORS.CLOSE_DIALOG_OLD))
-        ).not.toBeVisible();
+        await expect(page.locator(SELECTORS.CLOSE_DIALOG)).not.toBeVisible();
     });
 
     test('All the more-info dialog elements should exist', async ({ page }) => {
@@ -37,11 +29,7 @@ test.describe('HAQuerySelector for more-info dialogs', () => {
         // Open a more-info dialog
         await page.locator(SELECTORS.ENTITY_CARD).click();
 
-        // Restore this after Home Assistant 2025.3.x is released
-        //await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
-        await expect(
-            page.locator(SELECTORS.CLOSE_DIALOG).or(page.locator(SELECTORS.CLOSE_DIALOG_OLD))
-        ).toBeVisible();
+        await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
 
         // Only onMoreInfoDialogOpen should be triggered
         expect(await page.evaluate(() => window.__onMoreInfoDialogOpen.calledOnce)).toBe(true);
@@ -84,12 +72,7 @@ test.describe('HAQuerySelector for more-info dialogs', () => {
         // Return to the more-info dialog
         await page.locator(SELECTORS.DIALOG_GO_BACK_BUTTON).click();
 
-        // Restore this after Home Assistant 2025.3.x is released
-        //await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
-
-        await expect(
-            page.locator(SELECTORS.CLOSE_DIALOG).or(page.locator(SELECTORS.CLOSE_DIALOG_OLD))
-        ).toBeVisible();
+        await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
 
         // onMoreInfoDialogOpen should be triggered twice
         expect(await page.evaluate(() => window.__onMoreInfoDialogOpen.calledTwice)).toBe(true);
@@ -121,13 +104,8 @@ test.describe('HAQuerySelector for more-info dialogs', () => {
 
         // Return to the more-info dialog
         await page.locator(SELECTORS.DIALOG_GO_BACK_BUTTON).click();
-        
-        // Restore this after Home Assistant 2025.3.x is released
-        //await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
 
-        await expect(
-            page.locator(SELECTORS.CLOSE_DIALOG).or(page.locator(SELECTORS.CLOSE_DIALOG_OLD))
-        ).toBeVisible();
+        await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
 
         // onMoreInfoDialogOpen should be triggered thrice
         expect(await page.evaluate(() => window.__onMoreInfoDialogOpen.calledThrice)).toBe(true);
@@ -141,12 +119,7 @@ test.describe('HAQuerySelector for more-info dialogs', () => {
         // Open a more-info dialog
         await page.locator(SELECTORS.ENTITY_CARD).click();
 
-        // Restore this after Home Assistant 2025.3.x is released
-        //await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
-
-        await expect(
-            page.locator(SELECTORS.CLOSE_DIALOG).or(page.locator(SELECTORS.CLOSE_DIALOG_OLD))
-        ).toBeVisible();
+        await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
 
         // Open the history and logbook
         await page.locator(SELECTORS.DIALOG_HISTORY_BUTTON).click();
@@ -155,12 +128,7 @@ test.describe('HAQuerySelector for more-info dialogs', () => {
         // Return to the more-info dialog
         await page.locator(SELECTORS.DIALOG_GO_BACK_BUTTON).click();
 
-        // Restore this after Home Assistant 2025.3.x is released
-        //await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
-
-        await expect(
-            page.locator(SELECTORS.CLOSE_DIALOG).or(page.locator(SELECTORS.CLOSE_DIALOG_OLD))
-        ).toBeVisible();
+        await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
 
         // Open the config
         await page.locator(SELECTORS.DIALOG_CONFIG_BUTTON).click();
@@ -169,12 +137,7 @@ test.describe('HAQuerySelector for more-info dialogs', () => {
         // Return to the more-info dialog
         await page.locator(SELECTORS.DIALOG_GO_BACK_BUTTON).click();
 
-        // Restore this after Home Assistant 2025.3.x is released
-        //await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
-
-        await expect(
-            page.locator(SELECTORS.CLOSE_DIALOG).or(page.locator(SELECTORS.CLOSE_DIALOG_OLD))
-        ).toBeVisible();
+        await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
 
         const onMoreInfoDialogOpenArePromises = await page.evaluate(() => {
             const elements = [
@@ -224,13 +187,8 @@ test.describe('HAQuerySelector for more-info dialogs', () => {
 
         // Open a more-info dialog
         await page.locator(SELECTORS.ENTITY_CARD).click();
-        
-        // Restore this after Home Assistant 2025.3.x is released
-        //await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
 
-        await expect(
-            page.locator(SELECTORS.CLOSE_DIALOG).or(page.locator(SELECTORS.CLOSE_DIALOG_OLD))
-        ).toBeVisible();
+        await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
 
         const areOnMoreInfoDialogOpenTheRightElements = await page.evaluate(async () => {
 
@@ -300,13 +258,8 @@ test.describe('HAQuerySelector for more-info dialogs', () => {
 
         // Return to the more-info dialog
         await page.locator(SELECTORS.DIALOG_GO_BACK_BUTTON).click();
-        
-        // Restore this after Home Assistant 2025.3.x is released
-        //await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
 
-        await expect(
-            page.locator(SELECTORS.CLOSE_DIALOG).or(page.locator(SELECTORS.CLOSE_DIALOG_OLD))
-        ).toBeVisible();
+        await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
 
         // Open the config
         await page.locator(SELECTORS.DIALOG_CONFIG_BUTTON).click();
@@ -346,12 +299,7 @@ test.describe('HAQuerySelector for more-info dialogs', () => {
         // Return to the more-info dialog
         await page.locator(SELECTORS.DIALOG_GO_BACK_BUTTON).click();
 
-        // Restore this after Home Assistant 2025.3.x is released
-        //await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
-
-        await expect(
-            page.locator(SELECTORS.CLOSE_DIALOG).or(page.locator(SELECTORS.CLOSE_DIALOG_OLD))
-        ).toBeVisible();
+        await expect(page.locator(SELECTORS.CLOSE_DIALOG)).toBeVisible();
 
     });
 

--- a/tests/constants.ts
+++ b/tests/constants.ts
@@ -4,9 +4,7 @@ export const SELECTORS = {
     HA_SIDEBAR: 'ha-sidebar',
     HEADER: '.header',
     HEADER_HISTORY: 'ha-top-app-bar-fixed',
-    // Home Assistant 2025.2.x (remove when 2025.3.x is released)
-    CLOSE_DIALOG_OLD: 'mwc-icon-button[title="Dismiss dialog"]',
-    // Home Assistant > 2025.2.x
+    LINKS: 'ha-md-list > ha-md-list-item',
     CLOSE_DIALOG: 'mwc-icon-button[title="Close"]',
     ENTITY_CARD: 'hui-entities-card',
     DIALOG_HISTORY_BUTTON: 'mwc-icon-button[title="History"]',


### PR DESCRIPTION
Remove from the code the workarounds to make the tests compatible with old versions of `Home Assistant`.