### PR TITLE
Wait for the main events in the stubGlobalTestElements utility to avoid flaky tests

### DIFF
--- a/tests/05 - non-lovelace.spec.ts
+++ b/tests/05 - non-lovelace.spec.ts
@@ -9,7 +9,8 @@ test.describe('HAQuerySelector for non-lovelace dashboards', () => {
             {
                 pathname: 'history',
                 retries: 5,
-                delay: 5
+                delay: 5,
+                nonLovelace: true
             }
         );
     });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -8,6 +8,7 @@ interface Options {
     retries?: number;
     delay?: number;
     eventThreshold?: number;
+    nonLovelace?: boolean;
 }
 
 export const stubGlobalTestElements = async (
@@ -77,4 +78,9 @@ export const stubGlobalTestElements = async (
     }, options || {});
     // Timeout to allow the events to be triggered
     await page.waitForTimeout(500);
+    await page.waitForFunction(() => window.__onListen.calledOnce === true);
+    await page.waitForFunction(() => window.__onPanelLoad.calledOnce === true);
+    if (options?.nonLovelace !== true) {
+        await page.waitForFunction(() => window.__onLovelacePanelLoad.calledOnce === true);
+    }
 };


### PR DESCRIPTION
During the end-to-end tests, in the `stubGlobalTestElements` utility function, some Playwright `page.waitForFunction` have been placed to be sure that the function have been triggered before running the tests.