### PR TITLE
Migrate to ESM

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,8 +1,8 @@
-const tseslint = require('typescript-eslint');
-const js = require('@eslint/js');
-const globals = require('globals');
+import tseslint from 'typescript-eslint';
+import js from '@eslint/js';
+import globals from 'globals';
 
-module.exports = [
+export default [
     {
         languageOptions: {
             globals: {
@@ -34,7 +34,6 @@ module.exports = [
             '@typescript-eslint/ban-ts-ignore': 'off',
             '@typescript-eslint/ban-ts-comment': 'off',
             '@typescript-eslint/no-namespace': 'off'
-
         }
     }
 ];

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "javascript-library",
     "library"
   ],
+  "type": "module",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/index.d.ts",
@@ -38,7 +39,7 @@
   "scripts": {
     "clean": "rm -rf dist || true",
     "test:clean": "rm -rf .nyc_output coverage || true",
-    "build": "pnpm clean && rollup --config rollup.config.js --bundleConfigAsCjs",
+    "build": "pnpm clean && rollup --config rollup.config.mjs",
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
     "coverage:report": "nyc report --reporter=lcov --reporter=text-summary",
     "test:ts": "tsc --noEmit",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -1,4 +1,4 @@
-import packageJson from './package.json';
+import packageJson from './package.json' with { type: 'json' };
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import ts from '@rollup/plugin-typescript';
 import terser from '@rollup/plugin-terser';

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,6 +1,6 @@
 import { Page } from '@playwright/test';
 import { expect } from 'playwright-test-coverage';
-import path from 'path';
+import path from 'node:path';
 import { BASE_URL, SELECTORS } from './constants';
 
 interface Options {
@@ -18,7 +18,7 @@ export const stubGlobalTestElements = async (
 ) => {
 
     await page.addInitScript({
-        path: path.join(__dirname, '..', './node_modules/sinon/pkg/sinon.js'),
+        path: path.resolve('node_modules/sinon/pkg/sinon.js'),
     });
 
     await page.goto(`${BASE_URL}${options?.pathname ? '/' + options.pathname : ''}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,6 @@
       "@lib": ["./src/lib"]
     }
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "./playwright.config.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
This pull request migrates the project to ESM and add `type: module` to the `package.json`. Until now, the project was a mix of ESM syntax with workarounds to support CommonJS dependencies. This has been solved in this pull request.